### PR TITLE
Update validators.py

### DIFF
--- a/safe_filefield/validators.py
+++ b/safe_filefield/validators.py
@@ -3,7 +3,7 @@ import os
 
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import clamav
 from .utils import detect_content_type


### PR DESCRIPTION
ugettext_lazy has been deprecated in django 3.0 ==> https://docs.djangoproject.com/en/4.0/releases/3.0/
and ugettext_lazy has been removed in django 4.0 ==> https://docs.djangoproject.com/en/4.0/releases/4.0/
ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation' 

ugettext_lazy has been replaced with gettext_lazy